### PR TITLE
Add mathjax support

### DIFF
--- a/layout/_partial/import_js.ejs
+++ b/layout/_partial/import_js.ejs
@@ -36,3 +36,8 @@
         $(".post-toc-wrap").parent(".mdl-menu__container").css("position", "fixed");
     });
 </script>
+
+<!-- MathJax Load-->
+<% if (page.mathjax){ %>
+    <%- partial('_widget/mathjax') %>
+<% } %>

--- a/layout/_widget/mathjax.ejs
+++ b/layout/_widget/mathjax.ejs
@@ -13,5 +13,5 @@
         }
     });
 </script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>

--- a/layout/_widget/mathjax.ejs
+++ b/layout/_widget/mathjax.ejs
@@ -1,0 +1,17 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({"HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"], linebreaks: { automatic:true }, EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50) },
+        tex2jax: { inlineMath: [ ["$", "$"], ["\\(","\\)"] ], processEscapes: true, ignoreClass: "tex2jax_ignore|dno",skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']},
+        TeX: {  noUndefined: { attributes: { mathcolor: "red", mathbackground: "#FFEEEE", mathsize: "90%" } }, Macros: { href: "{}" } },
+        messageStyle: "none"
+    });
+</script>
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Queue(function() {
+        var all = MathJax.Hub.getAllJax(), i;
+        for(i=0; i < all.length; i += 1) {
+            all[i].SourceElement().parentNode.className += ' has-jax';
+        }
+    });
+</script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>


### PR DESCRIPTION
添加MathJax支持, 用以展示数学公式

### 使用方法

在文章的Front-Matter里添加 `mathjax: true`

### 测试样例

https://nagland.github.io/mathjax-support-demo/
