### PR TITLE
修复文章入口评论数一直显示暂无评论的问题

### DIFF
--- a/layout/_partial/Isolation-post_entry.ejs
+++ b/layout/_partial/Isolation-post_entry.ejs
@@ -64,7 +64,7 @@
 			<div class="post_entry-footer-comment">
 				<% if(theme.comment.use == "duoshuo"){ %>
 					<!-- Comment Number -->
-					<span class="ds-thread-count" data-thread-key="<%= post.id %>" data-count-type="comments"></span>
+					<span class="ds-thread-count" data-thread-key="<% if(theme.comment.duoshuo_thread_key == "id"){ %><%= post.id %><% } else { %><%= post.path %><% } %>" data-count-type="comments"></span>
 				<% } %>
 			</div>
 		</div>

--- a/layout/_partial/Paradox-post_entry.ejs
+++ b/layout/_partial/Paradox-post_entry.ejs
@@ -56,7 +56,7 @@
                 <!-- Comment Number -->
                 &nbsp;|&nbsp;
                 <span class="post_entry-comment" >
-                        <span class="ds-thread-count" data-thread-key="<%= post.id %>" data-count-type="comments"></span>
+                        <span class="ds-thread-count" data-thread-key="<% if(theme.comment.duoshuo_thread_key == "id"){ %><%= post.id %><% } else { %><%= post.path %><% } %>" data-count-type="comments"></span>
                 </span>
             <% } %>
             

--- a/layout/_widget/duoshuo.ejs
+++ b/layout/_widget/duoshuo.ejs
@@ -14,7 +14,7 @@
     <!-- 多说评论框 start -->
         <div class="ds-thread" 
             data-thread-key="<% if(theme.comment.duoshuo_thread_key == "id"){ %><%= page.id %><% } else { %><%= page.path %><% } %>" 
-            data-url="<%- config.url+ config.root + url_for(path) %>"
+            data-url="<%- config.url+ config.root + page.path %>"
             data-title="<%= page.title %>"></div>
     <!-- 多说评论框 end -->
 </div>


### PR DESCRIPTION
### 问题原因
本地thread-key与多说后台管理中对应文章的thread-key不一致导致，主题中文章入口的ejs文件中只对应了id的方式，未对应path方式。

### 修复问题
1. 主题配置中多说系统的thread-key采用path方式时，主页文章入口评论数一直显示暂无评论的问题；
2. 多说文章管理系统中文章url多一个／的问题；