### PR TITLE
Add Share to QQ / Add Share to Telegram / Add QrCode in your article / Fix a disqus issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ dropdown:
 pages:
     #about: "/about"
 
-
+qrcode: false
 
 # ---------------------------------------------------------------
 # Integrated Services

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -17,6 +17,7 @@ share:
     toGplus: "Share to Google+"
     toWeibo: "Share to Weibo"
     toQQ: "Share to QQ"
+    toTelegram: "Share to Telegram"
 title:
     category: "Category"
     tag: "Tag"

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -16,6 +16,7 @@ share:
     toLinkedIn: "Share to LinkedIn"
     toGplus: "Share to Google+"
     toWeibo: "Share to Weibo"
+    toQQ: "Share to QQ"
 title:
     category: "Category"
     tag: "Tag"

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -17,6 +17,7 @@ share:
     toGplus: "分享到 Google+"
     toWeibo: "分享到微博"
     toQQ: "分享到 QQ"
+    toTelegram: "分享到 Telegram"
 title:
     category: "分类"
     tag: "标签"

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -16,6 +16,7 @@ share:
     toLinkedIn: "分享到 LinkedIn"
     toGplus: "分享到 Google+"
     toWeibo: "分享到微博"
+    toQQ: "分享到 QQ"
 title:
     category: "分类"
     tag: "标签"

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -17,6 +17,7 @@ share:
     toGplus: "分享到 Google+"
     toWeibo: "分享到微博"
     toQQ: "分享到 QQ"
+    toTelegram: "分享到 Telegram"
 title:
     category: "分類"
     tag: "標籤"

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -16,6 +16,7 @@ share:
     toLinkedIn: "分享到 LinkedIn"
     toGplus: "分享到 Google+"
     toWeibo: "分享到微博"
+    toQQ: "分享到 QQ"
 title:
     category: "分類"
     tag: "標籤"

--- a/layout/_partial/Paradox-post-info.ejs
+++ b/layout/_partial/Paradox-post-info.ejs
@@ -19,7 +19,22 @@
         <span class="visuallyhidden">favorites</span>
     </button>
 -->
-    
+
+    <!-- Qrcode -->
+    <% if(theme.qrcode == true){ %>
+        <button id="article-functions-qrcode-button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
+            <i class="material-icons" role="presentation">explore</i>
+            <span class="visuallyhidden">explore</span>
+        </button>
+        <ul class="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect" for="article-functions-qrcode-button">
+            <li class="mdl-menu__item"><%= __('post.qrcode') %></li>
+            <img src="<%- qrcode(url, {
+                 margin: 2
+            }) %>">
+            </ul>
+    <% } %>
+
+
     <!-- Tags (bookmark) -->
     <button id="article-functions-viewtags-button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
         <i class="material-icons" role="presentation">bookmark</i>

--- a/layout/_partial/blog_info.ejs
+++ b/layout/_partial/blog_info.ejs
@@ -78,6 +78,16 @@
                     <%= __('share.toLinkedIn') %>
                 </li>
             </a>
+            <a class="post_share-link" href="http://connect.qq.com/widget/shareqq/index.html?site=<%= config.title %>&title=<%= config.title %>&summary=<%= config.description %>&pics=<%- config.url + theme.head.favicon %>&url=<%- config.url + config.root %>" target="_blank">
+                <li class="mdl-menu__item">
+                    <%= __('share.toQQ') %>
+                </li>
+            </a>
+            <a class="post_share-link" href="https://telegram.me/share/url?url=<%- config.url + config.root %>&text=<%= config.title %>" target="_blank">
+                <li class="mdl-menu__item">
+                    <%= __('share.toTelegram') %>
+                </li>
+            </a>
         </ul>
     </div>
 </div>

--- a/layout/_partial/post-info-share.ejs
+++ b/layout/_partial/post-info-share.ejs
@@ -51,4 +51,11 @@
             <%= __('share.toLinkedIn') %>
         </li>
     </a>
+
+    <!-- Share QQ -->
+    <a class="post_share-link" href="http://connect.qq.com/widget/shareqq/index.html?site=<%= config.title %>&title=<%= page.title %>&summary=<%= config.description %>&pics=<%- config.url + theme.head.favicon %>&url=<%- config.url +  url_for(path) %>" target="_blank">
+        <li class="mdl-menu__item">
+            <%= __('share.toQQ') %>
+        </li>
+    </a>
 </ul>

--- a/layout/_partial/post-info-share.ejs
+++ b/layout/_partial/post-info-share.ejs
@@ -58,4 +58,11 @@
             <%= __('share.toQQ') %>
         </li>
     </a>
+
+    <!-- Share Telegram -->
+    <a class="post_share-link" href="https://telegram.me/share/url?url=<%- config.url + url_for(path) %>&text=<%= page.title %>" target="_blank">
+        <li class="mdl-menu__item">
+            <%= __('share.toTelegram') %>
+        </li>
+    </a>
 </ul>

--- a/layout/_widget/disqus.ejs
+++ b/layout/_widget/disqus.ejs
@@ -1,7 +1,7 @@
 <div id="disqus_thread"></div>
 <script>
 	var disqus_config = function () {
-		this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
+		this.page.url = "<%- config.url + url_for(path) %>";  // Replace PAGE_URL with your page's canonical URL variable
 		this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
 	};
 


### PR DESCRIPTION
Add share to QQ button.
Add share to Telegram button.
Add QrCode in your article. This feature need hexo-helper-qrcode module and edit _config.yml in your theme folder with qrcode: true  To turn on Qrcode .