### PR TITLE
Fix title of post and add support of categories list

### DIFF
--- a/layout/_partial/sidebar-navigation.ejs
+++ b/layout/_partial/sidebar-navigation.ejs
@@ -50,6 +50,27 @@
             }) %>
         </ul>
     </li>
+	
+    <!-- Categories  -->
+<!--
+    <li class="dropdown">
+        <a href="#" class="ripple-effect dropdown-toggle" data-toggle="dropdown">
+            <i class="material-icons sidebar-material-icons">view_list</i>
+             <%= __("title.category") %>
+            <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+            <li>
+            <%- list_categories({
+                show_count: true,
+                amount: 5,
+                class: 'sidebar_archives',
+                style: 'none',
+                separator: '</li><li>'
+            }) %>
+        </ul>
+    </li>
+-->
 
     <!-- Divider -->
     <li class="divider"></li>


### PR DESCRIPTION
修复“当post有分类时，titile会显示成‘分类:xxx’”的问题<br />添加分类列表的支持，默认不开启（注释形式）