### PR TITLE
Add notag Front-Matter to disable showing tags

### DIFF
--- a/layout/_partial/Paradox-post-info.ejs
+++ b/layout/_partial/Paradox-post-info.ejs
@@ -36,6 +36,7 @@
 
 
     <!-- Tags (bookmark) -->
+    <% if(page.notag != true){ %>
     <button id="article-functions-viewtags-button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
         <i class="material-icons" role="presentation">bookmark</i>
         <span class="visuallyhidden">bookmark</span>
@@ -49,6 +50,7 @@
             separator: '</li><li class="mdl-menu__item">'
         }) %>
     </ul>
+    <% } %>
     
     <!-- Share -->
     <%- partial("_partial/post-info-share") %>


### PR DESCRIPTION
Add a new Front-Matter "notag" to disable showing tags to avoid undefined tags in page.

use "notag: true" to disable tag showing.

![image](https://cloud.githubusercontent.com/assets/8038511/21564409/2d89fd1c-cec8-11e6-91f8-9d32ce7da9d4.png)

![image](https://cloud.githubusercontent.com/assets/8038511/21564419/475b5fce-cec8-11e6-90ba-6755a9f9ebbf.png)
