### PR TITLE
fix generate MultiLine Slogan Error when slogan is null

### DIFF
--- a/layout/_partial/daily_pic.ejs
+++ b/layout/_partial/daily_pic.ejs
@@ -4,10 +4,12 @@
     <!-- Pic & Slogan -->
     <div class="mdl-card__media mdl-color-text--grey-50" style="background-image:url(<%= theme.img.daily_pic %>)">
         <p class="index-top-block-slogan"><a href="<%= theme.url.daily_pic %>">
-        <% if(typeof theme.uiux.slogan == "string") { %>
-          <%= theme.uiux.slogan %>
-        <% } else { %>
-          <%- theme.uiux.slogan.join("<br>") %>
+        <% if(theme.uiux.slogan !=null) { %>
+          <% if(typeof theme.uiux.slogan == "string") { %>
+            <%= theme.uiux.slogan %>
+          <% } else { %>
+            <%- theme.uiux.slogan.join("<br>") %>
+          <% } %>
         <% } %>
         </a></p>
     </div>


### PR DESCRIPTION
Fix [#84](https://github.com/viosey/hexo-theme-material/issues/84) 
When slogan in _config.yml is not set. `hexo generate` will show you TypeError.