### PR TITLE
Boost qrcode,tags,share menu in article

### DIFF
--- a/layout/_widget/disqus.ejs
+++ b/layout/_widget/disqus.ejs
@@ -1,14 +1,18 @@
 <div id="disqus_thread"></div>
 <script>
-	var disqus_config = function () {
-		this.page.url = "<%- config.url + url_for(path) %>";  // Replace PAGE_URL with your page's canonical URL variable
-		this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
-	};
+	$("html").ready(function(){
+		setTimeout(function(){
+			var disqus_config = function () {
+				this.page.url = "<%- config.url + url_for(path) %>";  // Replace PAGE_URL with your page's canonical URL variable
+				this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+			};
 
-	(function() { // DON'T EDIT BELOW THIS LINE
-		var d = document, s = d.createElement('script');
-		s.src = '//<%= theme.comment.shortname %>.disqus.com/embed.js';
-		s.setAttribute('data-timestamp', +new Date());
-		(d.head || d.body).appendChild(s);
-	})();
+			(function() { // DON'T EDIT BELOW THIS LINE
+				var d = document, s = d.createElement('script');
+				s.src = '//<%= theme.comment.shortname %>.disqus.com/embed.js';
+				s.setAttribute('data-timestamp', +new Date());
+				(d.head || d.body).appendChild(s);
+			})();
+		},1500);
+	});
 </script>


### PR DESCRIPTION
Before: 
![1](https://cloud.githubusercontent.com/assets/8038511/21580472/0a5e0f6a-d033-11e6-9830-25bb90ce2140.gif)

After:
![2](https://cloud.githubusercontent.com/assets/8038511/21580475/216269d6-d033-11e6-8149-124fc2cb7e43.gif)

Now you can use qrcode,tags,share menu when article finished loading instead of when comment finish loading. (Usually, load comment js file from disqus is slow.)
