### PR TITLE
feat(pin): support pin posts on the top of the list

### DIFF
--- a/_config.template.yml
+++ b/_config.template.yml
@@ -126,7 +126,7 @@ pages:
 qrcode: false
 
 # Support Pin posts on the top of the list
-pin_post: false
+topPost: false
 
 # ---------------------------------------------------------------
 # Integrated Services

--- a/_config.template.yml
+++ b/_config.template.yml
@@ -125,6 +125,9 @@ pages:
 # Qrcode for redirect at other device
 qrcode: false
 
+# Support Pin posts on the top of the list
+pin_post: false
+
 # ---------------------------------------------------------------
 # Integrated Services
 # ---------------------------------------------------------------

--- a/layout/_partial/Isolation-post_entry.ejs
+++ b/layout/_partial/Isolation-post_entry.ejs
@@ -28,7 +28,7 @@
     <div class="post_entry-content mdl-color-text--grey-600 mdl-card__supporting-text">
         <!-- Post Title -->
         <p class="post_entry-title">
-            <a href="<%= url_for(post.path) %>"><%= post.title %></a>
+            <a href="<%= url_for(post.path) %>"><% if(pin) { %><span>[Top]</span><% } %><%= post.title %></a>
         </p>
 
         <!-- Post Excerpt -->

--- a/layout/_partial/Paradox-post_entry.ejs
+++ b/layout/_partial/Paradox-post_entry.ejs
@@ -14,7 +14,7 @@
     <% } %>
 
         <!-- Post Title -->
-        <p class="article-headline-p"><a href="<%= url_for(post.path) %>"><%= post.title %></a></p>
+        <p class="article-headline-p"><a href="<%= url_for(post.path) %>"><% if(pin) { %><span>[Top]</span><% } %><%= post.title %></a></p>
     </div>
 
     <!-- Post Excerpt -->

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -47,7 +47,7 @@
             }) %>
         </nav>
     <% } %>
-
+    
     <% if(theme.scheme === 'Paradox') { %>
         <%- partial('_partial/Paradox-post_entry-thumbnail') %>
     <% } %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -8,14 +8,14 @@
     <div class="locate-thumbnail-symbol"></div>
     
     <!-- Pin on top -->
-    <% if(theme.pin_post) { %>
+    <% if(theme.topPost) { %>
         <% if(hasposttop(page.posts)) { %>
             <% getposttop(page.posts).each(function(toppost){ %> 
-                <% if(theme.scheme == "Paradox"){ %>
+                <% if(theme.scheme === "Paradox"){ %>
                     <!-- Paradox Thumbnail -->
                     <%- partial('_partial/Paradox-post_entry', { post: toppost, index: true, pin: true }) %>
                 <% } %>
-                <% if(theme.scheme == "Isolation"){ %>
+                <% if(theme.scheme === "Isolation"){ %>
                     <!-- Isolation Thumbnail -->
                     <%- partial('_partial/Isolation-post_entry', { post: toppost, index: true, pin: true }) %>
                 <% } %>
@@ -25,7 +25,7 @@
     
     <!-- Normal Post -->
     <% page.posts.each(function(post) { %>
-        <% if(!(theme.pin_post && post.top)) { %>
+        <% if(!(theme.topPost && post.top)) { %>
         <% if(theme.scheme === 'Paradox') { %>
             <!-- Paradox Thumbnail -->
             <%- partial('_partial/Paradox-post_entry', { post: post, index: true, pin: false }) %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -6,15 +6,34 @@
         <%- partial('_partial/blog_info') %>
     <% } %>
     <div class="locate-thumbnail-symbol"></div>
-
+    
+    <!-- Pin on top -->
+    <% if(theme.pin_post) { %>
+        <% if(hasposttop(page.posts)) { %>
+            <% getposttop(page.posts).each(function(toppost){ %> 
+                <% if(theme.scheme == "Paradox"){ %>
+                    <!-- Paradox Thumbnail -->
+                    <%- partial('_partial/Paradox-post_entry', { post: toppost, index: true, pin: true }) %>
+                <% } %>
+                <% if(theme.scheme == "Isolation"){ %>
+                    <!-- Isolation Thumbnail -->
+                    <%- partial('_partial/Isolation-post_entry', { post: toppost, index: true, pin: true }) %>
+                <% } %>
+            <% }); %>
+        <% } %>
+    <% } %>
+    
+    <!-- Normal Post -->
     <% page.posts.each(function(post) { %>
+        <% if(!(theme.pin_post && post.top)) { %>
         <% if(theme.scheme === 'Paradox') { %>
             <!-- Paradox Thumbnail -->
-            <%- partial('_partial/Paradox-post_entry', { post: post, index: true }) %>
+            <%- partial('_partial/Paradox-post_entry', { post: post, index: true, pin: false }) %>
         <% } %>
         <% if(theme.scheme === 'Isolation') { %>
             <!-- Isolation Thumbnail -->
-            <%- partial('_partial/Isolation-post_entry', { post: post, index: true }) %>
+            <%- partial('_partial/Isolation-post_entry', { post: post, index: true, pin: false }) %>
+        <% } %>
         <% } %>
     <% }); %>
 


### PR DESCRIPTION
<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
-->

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:
 
**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

<!-- ----------- -->
-----------
Testing steps:
1. Install `hexo-helper-post-top` plugin using `npm install hexo-helper-post-top --save`
2. Change the `_config.yml` in the theme proptites `pin_post` to true. 
3. In the post which you want to pin on the top, add `top: true` to the `Front-matter`
4. Run `hexo server` to show the changes. All the post you want to pin on the top is now on the top of the index with a `[Top]` string in the title.

We also need some new CSS style to show this feature in a beautiful way. 

-----------
Support pin the posts on the top of the list in index  

-----------

# BREAKING CHANGE:  
config file has changed.
To migrate the code, add `topPost: false` to your _config.yml in the theme

Closes #23 