### PR TITLE
chore(contributing): update master from canary

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOUT INVESTIGATING
+-->
+
+**I certify that I have first consulted** (check all with "x")
+
+- [ ] [Hexo documentation](https://hexo.io/docs/)
+- [ ] [Material theme documentation](https://material.viosey.com/)
+- [ ] [Material theme issues](https://github.com/viosey/hexo-theme-material/issues?utf8=%E2%9C%93&q=is%3Aissue)
+
+
+**I'm submitting a**  (check one with "x")
+
+- [ ] bug report
+- [ ] feature request
+- [ ] support request
+
+<!-- ----------- -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
+-->
+
+**Contributing rules**
+
+- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
+- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
+- Remove the `Contributing rules` part from this description
+- Fill out the other parts from this description
+
+
+<!-- ----------- -->
+
+**What kind of change does this PR introduce?** (check one with "x")
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Other... Please describe:
+
+**Does this PR introduce a breaking change?** (check one with "x")
+
+- [ ] Yes
+- [ ] No
+
+
+____
+
+**Description**
+
+No description.
+
+____
+
+**Verification steps**
+
+No verification steps.

--- a/contributing.json
+++ b/contributing.json
@@ -2,13 +2,18 @@
 {
   "commit": {
     "subject_cannot_be_empty": true,
-    "subject_must_be_longer_than": 4,
     "subject_must_be_in_tense": "imperative",
-    "subject_must_not_end_with_dot": true
+    "subject_must_not_end_with_dot": true,
+    "subject_lines_must_be_shorter_than": 51,
+    "subject_must_be_single_line": true,
+    "subject_must_be_in_case": "lower",
+    "subject_must_include_prefix": {
+      "prefixes": ["feat", "fix", "docs", "style", "refactor", "test", "chore"],
+      "require_after_prefix": "(*): "
+    }
   },
   "pull_request": {
     "subject_cannot_be_empty": true,
-    "subject_must_be_longer_than": 4,
     "subject_must_be_in_tense": "imperative",
     "subject_must_start_with_case": "lower",
     "subject_must_not_end_with_dot": true,
@@ -17,19 +22,19 @@
       "require_after_prefix": "(*): "
     },
     "body_cannot_be_empty": true,
-    "body_must_include_verification_steps": true,
-    "body_must_include_screenshot": ["html", "css"]
+    "body_must_include_verification_steps": true
   },
   "issue": {
     "subject_cannot_be_empty": true,
-    "subject_must_be_longer_than": 4,
-    "subject_must_be_in_tense": "imperative",
-    "subject_must_start_with_case": "lower",
+    "subject_must_start_with_case": "upper",
     "subject_must_not_end_with_dot": true,
-
     "body_cannot_be_empty": true,
-    "body_must_include_reproduction_steps": ["bug"],
-
-    "label_must_be_set": true
-  }
+    "body_must_include_reproduction_steps": ["bug"]
+  },
+  "branch": {
+    "name_must_be_longer_than": 4,
+    "name_must_include_prefix": {
+      "prefixes": ["feat", "fix", "refactor", "chore"],
+      "require_after_prefix": "/"
+    }
 }


### PR DESCRIPTION
New PR (even targeting `canary` branch) uses `contributing.json` from `master` branch so we are sill blocked by rules like `"subject_must_be_longer_than": 4` and `"body_must_include_screenshot": ["html", "css"]`. Also, branch names are not checked.

Besides, PR targeting `master` does not use templates.

No verification steps.