### PR TITLE
Disabled browsers' autocompleter

### DIFF
--- a/layout/_partial/Paradox-search.ejs
+++ b/layout/_partial/Paradox-search.ejs
@@ -5,7 +5,7 @@
             <i class="material-icons mdl-color-text--white" role="presentation">search</i>
         </label>
 
-        <form id="search-form" method="get" action="//google.com/search" accept-charset="UTF-8" class="mdl-textfield__expandable-holder" target="_blank">
+        <form autocomplete="off" id="search-form" method="get" action="//google.com/search" accept-charset="UTF-8" class="mdl-textfield__expandable-holder" target="_blank">
             <input class="mdl-textfield__input search-input" type="search" name="q" id="search" placeholder="">
             <label id="search-form-label" class="mdl-textfield__label" for="search"></label>
 
@@ -21,7 +21,7 @@
             <i class="material-icons mdl-color-text--white" role="presentation">search</i>
         </label>
 
-        <form id="search-form" class="mdl-textfield__expandable-holder" action="">
+        <form autocomplete="off" id="search-form" class="mdl-textfield__expandable-holder" action="">
             <input class="mdl-textfield__input search-input st-default-search-input" type="text" name="q" id="search">
             <label id="search-form-label" class="mdl-textfield__label" for="search"></label>
         </form>
@@ -35,7 +35,7 @@
             <i class="material-icons mdl-color-text--white" role="presentation">search</i>
         </label>
 
-        <form id="search-form" class="mdl-textfield__expandable-holder">
+        <form autocomplete="off" id="search-form" class="mdl-textfield__expandable-holder">
             <input type="text" id="search" class="form-control mdl-textfield__input search-input" name="q" results="0" placeholder=""/>
             <label id="search-form-label" class="mdl-textfield__label" for="search"></label>
         </form>


### PR DESCRIPTION
<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
-->

**Contributing rules**

- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
- Remove the `Contributing rules` part from this description
- Fill out the other parts from this description


<!-- ----------- -->

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

Fixes #168 where browsers would hide search suggestions with their own.

Only added `autocomplete="off"` in 3 places in one file.

____

**Verification steps**

No verification steps.
