### PR TITLE
fix(disqusclick): let disqus_click_to_load button automatically hide

### DIFF
--- a/layout/_widget/disqus_click.ejs
+++ b/layout/_widget/disqus_click.ejs
@@ -33,7 +33,7 @@
 </style>
 	
 <!-- add data-ripple attribute -->
-<div class="btn1"> 
+<div class="btn_click_load"> 
     <button data-ripple><%= __('post.comments_load_button') %></button>
 </div>
 	
@@ -46,21 +46,19 @@
 </script>
 
 <script>
-    $('html').ready(function() {
-        $(".btn1").click(function() {  //click to load comments
-            var disqus_config = function () {
-                this.page.url = '<%- config.url + url_for(path) %>';  // Replace PAGE_URL with your page's canonical URL variable
-                this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
-            };
-
-            (function() { // DON'T EDIT BELOW THIS LINE
-                var d = document;
-                var s = d.createElement('script');
-                s.src = '//<%= theme.comment.shortname %>.disqus.com/embed.js';
-                s.setAttribute('data-timestamp', + new Date());
-                (d.head || d.body).appendChild(s);
-            })();
-       });
+    $('.btn_click_load').click(function() {  //click to load comments
+        var disqus_config = function () {
+            this.page.url = '<%- config.url + url_for(path) %>';  // Replace PAGE_URL with your page's canonical URL variable
+            this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+        };
+        (function() { // DON'T EDIT BELOW THIS LINE
+            var d = document;
+            var s = d.createElement('script');
+            s.src = '//<%= theme.comment.shortname %>.disqus.com/embed.js';
+            s.setAttribute('data-timestamp', + new Date());
+            (d.head || d.body).appendChild(s);
+        })();
+        $('.btn_click_load').css('display','none');
     });
 </script>
   	


### PR DESCRIPTION
<!--IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING-->

**Contributing rules**

- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
- Remove the `Contributing rules` part from this description
- Fill out the other parts from this description


<!-- ----------- -->

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**
fix a bug about disqus_click_to_load button can't automatically hide after the disqus comments has already loaded

____

**Verification steps**
- Check the changed files
- Configure _config.yml in Material on line 179 as "disqus_click", then run a `hexo clean` `hexo g` & `hexo s` to find out whether it is working. 
