### PR TITLE
fix(lsloader): Fix that does not generate hex when missing .js and .css suffixes

### DIFF
--- a/scripts/lib/css_lsload.js
+++ b/scripts/lib/css_lsload.js
@@ -13,12 +13,11 @@ function cssHelper() {
 
     if (i) result += '\n';
 
-    var localpath = path_for.call(this,path);
-
     if (Array.isArray(path)) {
       result += jsHelper.apply(this, path);
     } else {
       if (path.indexOf('?') < 0 && path.substring(path.length - 4, path.length) !== '.css') path += '.css';
+      var localpath = path_for.call(this,path);
       result += '<style id="' + path + '"></style><script>if(typeof window.lsLoadCSSMaxNums === "undefined")window.lsLoadCSSMaxNums = 0;' +
         'window.lsLoadCSSMaxNums++;' +
         'lsloader.load("' + path + '","' +

--- a/scripts/lib/js_lsload.js
+++ b/scripts/lib/js_lsload.js
@@ -13,12 +13,11 @@ function jsHelper() {
 
     if (i) result += '\n';
 
-    var localpath = path_for.call(this,path);
-
     if (Array.isArray(path)) {
       result += jsHelper.apply(this, path);
     } else {
       if (path.indexOf('?') < 0 && path.substring(path.length - 3, path.length) !== '.js') path += '.js';
+      var localpath = path_for.call(this,path);
       result += '<script>lsloader.load("' + path + '","' +
         require("../../../../node_modules/hexo/lib/plugins/helper/url_for").call(this,path) +
         (fs.existsSync(localpath)?'?' + get_file_hex(localpath):'') + '")</script>'


### PR DESCRIPTION
<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
-->

**Contributing rules**

- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
- Remove the `Contributing rules` part from this description
- Fill out the other parts from this description

> If you don't do so, we might change your pull request's title and using `squash` to merge your changed.

<!-- ----------- -->

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

fix(lsloader): Fix that does not generate hex when missing .js and .css suffixes

偶然发现，在不启用 cdn 且缺少 .js 和 .css 后缀时，会判定找不到文件，不会生成文件hex值。

____

**Verification steps**

No verification steps.
