### PR TITLE
Drop deprecated jQuery `.load` method

### DIFF
--- a/layout/_partial/import_js.ejs
+++ b/layout/_partial/import_js.ejs
@@ -57,7 +57,7 @@
 
 <!-- Window Load-->
 <script type="text/ls-javascript" id="window-load">
-    $(window).load(function() {
+    $(window).on('load', function() {
         // Post_Toc parent position fixed
         $('.post-toc-wrap').parent('.mdl-menu__container').css('position', 'fixed');
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

According to [jQuery blog](https://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/)
> `.load`, `.unload`, and `.error`, deprecated since jQuery 1.8, are no more. Use `.on()` to register listeners.

____

**Verification steps**

Check the latest version of jQuery. Method `.load` is no longer bundled.
