### PR TITLE
fix(background): set bing background before lazyload initialization

### DIFF
--- a/layout/_partial/import_js.ejs
+++ b/layout/_partial/import_js.ejs
@@ -91,6 +91,16 @@
 <% if (page.mathjax) { %>
     <%- partial('_widget/mathjax') %>
 <% } %>
+
+<!-- Bing Background -->
+<% if(theme.background.bing.enable) { %>
+<script type="text/ls-javascript" id="Bing-Background-script">
+    queue.offer(function(){
+        $('body').attr('data-original', 'https://api.i-meto.com/bing?<%= theme.background.bing.parameter %>');
+    });
+</script>
+<% } %>
+
 <script type="text/ls-javascript" id="lazy-load">
     // Offer LazyLoad
     queue.offer(function(){
@@ -106,15 +116,6 @@
         },200);
     });
 </script>
-
-<!-- Bing Background -->
-<% if(theme.background.bing.enable) { %>
-<script type="text/ls-javascript" id="Bing-Background-script">
-    queue.offer(function(){
-        $('body').attr('data-original', 'https://api.i-meto.com/bing?<%= theme.background.bing.parameter %>');
-    });
-</script>
-<% } %>
 
 <!-- Custom Footer -->
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

In my chrome, the bing background fails to be loaded. After I swap the two js code blocks (1. set the `data-original` attr of `body` 2. initialize lazyload), the bing picture is successfully fetched.

I'm no expert in javascript, my best guess is that the order in which codes are written is important for `lsloader.runInlineScript()`.

____

**Verification steps**

No verification steps.
