### PR TITLE
fix the gitalk bug

### DIFF
--- a/layout/_widget/comment/gitalk/main.ejs
+++ b/layout/_widget/comment/gitalk/main.ejs
@@ -13,7 +13,8 @@
             owner: '<%= theme.comment.gitalk_owner %>',
             admin: ['<%= theme.comment.gitalk_owner %>'],
             // facebook-like distraction free mode
-            distractionFreeMode: false
+            distractionFreeMode: false,
+            id: '<%=  page.title.substr(0,48) %>'
         })
    gitalk.render('gitalk-container')
 </script>


### PR DESCRIPTION
This bug happens when the url length of a post is longer than 50 characters. I fixed the parameter 'id' in 'gitalk/main.ejs'.

<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
-->

**Contributing rules**

- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
- Remove the `Contributing rules` part from this description
- Fill out the other parts from this description

> If you don't do so, we might change your pull request's title and using `squash` to merge your changed.

<!-- ----------- -->

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

This bug happens when the url length of a post is longer than 50 characters. I fixed the parameter 'id' in 'gitalk/main.ejs'.

____

**Verification steps**

No verification steps.
