### PR TITLE
Fix gitalk that id was too long to create a issue tag.

### DIFF
--- a/layout/_widget/comment/gitalk/main.ejs
+++ b/layout/_widget/comment/gitalk/main.ejs
@@ -4,16 +4,25 @@
 <link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
 
 <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
+<script src="https://cdn.bootcss.com/blueimp-md5/2.10.0/js/md5.js"></script>
 
 <script>
+    var id = location.pathname;
+
+    if (Date.parse('<%= page.date %>') - Date.parse('2018-03-01') > 0 ||
+        '<%= typeof page["gitalk"]!=="undefined"?"true":"false" %>' !== 'true') {
+        id = md5(location.pathname)
+    }
+
     var gitalk = new Gitalk({
-            clientID: '<%= theme.comment.gitalk_client_id %>',
-            clientSecret: '<%= theme.comment.gitalk_client_secret %>',
-            repo: '<%= theme.comment.gitalk_repo %>',
-            owner: '<%= theme.comment.gitalk_owner %>',
-            admin: ['<%= theme.comment.gitalk_owner %>'],
-            // facebook-like distraction free mode
-            distractionFreeMode: false
-        })
-   gitalk.render('gitalk-container')
+        clientID: '<%= theme.comment.gitalk_client_id %>',
+        clientSecret: '<%= theme.comment.gitalk_client_secret %>',
+        repo: '<%= theme.comment.gitalk_repo %>',
+        owner: '<%= theme.comment.gitalk_owner %>',
+        admin: ['<%= theme.comment.gitalk_owner %>'],
+        id: id,
+        // facebook-like distraction free mode
+        distractionFreeMode: false
+    })
+    gitalk.render('gitalk-container')
 </script>

--- a/layout/_widget/comment/gitalk/main.ejs
+++ b/layout/_widget/comment/gitalk/main.ejs
@@ -10,8 +10,12 @@
     var id = location.pathname;
 
     if (Date.parse('<%= page.date %>') - Date.parse('2018-03-01') > 0 ||
-        '<%= typeof page["gitalk"]!=="undefined"?"true":"false" %>' !== 'true') {
+        '<%=  page.gitalk =="md5" ?"true":"false" %>' === 'true') {
         id = md5(location.pathname)
+    }
+
+    if ('<%= page.gitalk =="plaintext"?"true":"false" %>' === 'true') {
+        id = location.pathname;
     }
 
     var gitalk = new Gitalk({


### PR DESCRIPTION
<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR PULL REQUESTS WITHOUT INVESTIGATING
-->

**Contributing rules**

- Fork the repo and create your branch from `canary`. Then be sure to put the `canary` branch as the target for your pull request.
- Please be sure to follow the [contributing guidelines](https://github.com/viosey/hexo-theme-material/blob/master/CONTRIBUTING.md), especially for commit message
- Remove the `Contributing rules` part from this description
- Fill out the other parts from this description

> If you don't do so, we might change your pull request's title and using `squash` to merge your changed.

<!-- ----------- -->

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


____

**Description**

修复gitalk的id过长导致无法创建评论框的问题。

____

**Verification steps**

- 设定在2018-03-01之后的评论框使用md5加密的pathname作为id，之前已创建的还使用明文
- 这个时间之前的文章如果需要创建评论需要在文章头部加上`gitalk:md5`来强行使用md5
- 这个时间之后的已创建的评论框需要需要在文章头部加上`gitalk: plaintext`来强行使用明文
